### PR TITLE
Run CI in Node.js 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node 18 is the "current" version of Node. Drop the inbetween version 17 and add 18 to the version matrix.